### PR TITLE
Upside Down Labs MSP430 Breadstick support

### DIFF
--- a/boards/upsidedownlabs-breadstick.json
+++ b/boards/upsidedownlabs-breadstick.json
@@ -1,0 +1,19 @@
+ {
+  "build": {
+    "core": "msp430",
+    "f_cpu": "16000000L",
+    "mcu": "msp430g2553",
+    "variant": "UpsideDownLabs-Breadstick"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Upside Down Labs MSP430 Breadstick",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 16384,
+    "protocol": "msptool"
+  },
+  "url": "https://github.com/upsidedownlabs/MSP430-Breadstick",
+  "vendor": "Upside Down Labs"
+}

--- a/builder/main.py
+++ b/builder/main.py
@@ -1,3 +1,4 @@
+# Copyright 2021 Upside Down Labs <contact@upsidedownlabs.tech>
 # Copyright 2014-present PlatformIO <contact@platformio.org>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -150,10 +151,24 @@ if env.subst("$UPLOAD_PROTOCOL") == "dslite":
     )
     upload_target = target_elf
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
+elif env.subst("$UPLOAD_PROTOCOL") == "msptool":
+    env.Replace(
+        UPLOADER=join(env.PioPlatform().get_package_dir("tool-msptool") or "", "msptool.py"),
+        MSPTOOLDIR=env.PioPlatform().get_package_dir("tool-msptool"),
+        UPLOADCMD='"$PYTHONEXE" "$UPLOADER" -d $MSPTOOLDIR -p $UPLOAD_PORT -f $SOURCES'
+    )
+    upload_target = target_elf
+    upload_actions = [
+        env.VerboseAction(env.AutodetectUploadPort, "Looking for upload port..."),
+        env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")
+    ]
+    
 
-target_upload = env.Alias("upload", upload_target,
-                          env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE"))
-AlwaysBuild(target_upload)
+if env.subst("$UPLOAD_PROTOCOL") == "msptool":
+    env.AddPlatformTarget("upload", upload_target, upload_actions, "Upload")
+else:
+    target_upload = env.Alias("upload", upload_target, env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE"))
+    AlwaysBuild(target_upload)
 
 #
 # Default targets

--- a/platform.json
+++ b/platform.json
@@ -50,6 +50,12 @@
       "optional": true,
       "owner": "platformio",
       "version": "~1.90200.1400"
+    },
+    "tool-msptool": {
+      "type": "uploader",
+      "optional": true,
+      "owner": "lorforlinux",
+      "version": "~0.3"
     }
   }
 }


### PR DESCRIPTION
Hey,

This PR adds the support for [Upside Down Labs MSP430 Breadstick](https://github.com/upsidedownlabs/MSP430-Breadstick) dev-board. The [msptool](https://github.com/upsidedownlabs/msptool) has been published as `tool-msptool` and works great with the submitted code.

One task that remains is to add the `UpsideDownLabs-Breadstick` variant to the `framework-energiamsp430`. I have the code ready and tested please let me know where do I have to submit it. I was not able to figure this part, I hope someone can help me here :)