### PR TITLE
maxSizeChange

### DIFF
--- a/boards/lpmsp430f5529.json
+++ b/boards/lpmsp430f5529.json
@@ -33,7 +33,7 @@
   "name": "TI LaunchPad MSP-EXP430F5529LP",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 48128,
+    "maximum_size": 131072,
     "protocol": "dslite"
   },
   "url": "http://www.ti.com/ww/en/launchpad/launchpads-msp430-msp-exp430f5529lp.html",


### PR DESCRIPTION
Using the real flash capability of the LaunchPad MSP-EXP430F5529LP which is 128kByte (131072 Bytes)