### PR TITLE
Add Support for MSP430FR2355 

### DIFF
--- a/boards/lpmsp430fr2355.json
+++ b/boards/lpmsp430fr2355.json
@@ -1,0 +1,41 @@
+{
+  "build": {
+    "core": "msp430",
+    "extra_flags": "-DENERGIA_ARCH_MSP430 -DENERGIA_MSP_EXP430FR2355LP",
+    "f_cpu": "16000000L",
+    "hwids": [
+      [
+        "0x2341",
+        "0x0c9f"
+      ]
+    ],
+    "mcu": "msp430fr2355",
+    "variant": "MSP-EXP430FR2355LP"
+  },
+  "debug": {
+    "tools": {
+      "mspdebug": {
+        "onboard": true,
+        "server": {
+          "arguments": [
+            "$UPLOAD_PROTOCOL",
+            "gdb"
+          ],
+          "executable": "mspdebug",
+          "package": "tool-mspdebug"
+        }
+      }
+    }
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "TI LaunchPad MSP-EXP430FR2355LP",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "dslite"
+  },
+  "url": "http://www.ti.com/product/MSP430FR2355",
+  "vendor": "TI"
+}


### PR DESCRIPTION
Tested on my [MSP-EXP430FR2355 dev board](https://www.ti.com/tool/MSP-EXP430FR2355). 

One thing I can't explain is that sometimes I get an 'error: MSP430: Error initializing emulator: Interface Communication error'. Simply waiting for 30s or so and trying again fixes the issue.