### PR TITLE
made ready for newer GCC compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://github.com/platformio/platform-timsp430/workflows/Examples/badge.svg)](https://github.com/platformio/platform-timsp430/actions)
 
+NOTE: the default toolchain for MSP430 platformIO is still on GCC version 4.6.3, which means C++0x. This github fork uses the radically more modern GCC compiler: https://github.com/maxgerhardt/pio-toolchaintimsp430-new.git      
+(i'm not sure, but i believe all/most-of-what maxgethardt did was just add a package.json file to the opensource GCC toolchain from TI: https://www.ti.com/tool/MSP430-GCC-OPENSOURCE ).       
+I have almost no idea what i'm doing when it comes to compilers, so when i got a few linker errors, i just googled and found '-fno-rtti' as an extra argument to fix things. It does at least compile for me now, actual hardware testing still TBD.
+
 MSP430 microcontrollers (MCUs) from Texas Instruments (TI) are 16-bit, RISC-based, mixed-signal processors designed for ultra-low power. These MCUs offer the lowest power consumption and the perfect mix of integrated peripherals for thousands of applications.
 
 * [Home](https://registry.platformio.org/platforms/platformio/timsp430) (home page in the PlatformIO Registry)
@@ -18,6 +22,8 @@ MSP430 microcontrollers (MCUs) from Texas Instruments (TI) are 16-bit, RISC-base
 [env:stable]
 platform = timsp430
 board = ...
+platform_packages = toolchain-timsp430@https://github.com/maxgerhardt/pio-toolchaintimsp430-new.git  ; uses a newer GCC version from TI (old toolchain was C++0x)
+build_flags = '-fno-rtti' ; not sure what it does or why it helps, but it does. google: https://en.wikipedia.org/wiki/Run-time_type_information
 ...
 ```
 
@@ -27,6 +33,8 @@ board = ...
 [env:development]
 platform = https://github.com/platformio/platform-timsp430.git
 board = ...
+platform_packages = toolchain-timsp430@https://github.com/maxgerhardt/pio-toolchaintimsp430-new.git  ; uses a newer GCC version from TI (old toolchain was C++0x)
+build_flags = '-fno-rtti' ; not sure what it does or why it helps, but it does. google: https://en.wikipedia.org/wiki/Run-time_type_information
 ...
 ```
 

--- a/builder/frameworks/energia.py
+++ b/builder/frameworks/energia.py
@@ -51,7 +51,7 @@ env.Append(
         join(FRAMEWORK_DIR, "cores", env.BoardConfig().get("build.core")),
         join(variants_dir, board.get("build.variant")),
         join(platform.get_package_dir(
-            "toolchain-timsp430"), "msp430", "include")
+            "toolchain-timsp430"), "msp430-elf", "include")
     ],
 
     LIBSOURCE_DIRS=[

--- a/builder/main.py
+++ b/builder/main.py
@@ -21,14 +21,14 @@ from SCons.Script import (COMMAND_LINE_TARGETS, AlwaysBuild, Builder, Default,
 env = DefaultEnvironment()
 
 env.Replace(
-    AR="msp430-ar",
-    AS="msp430-as",
-    CC="msp430-gcc",
-    CXX="msp430-g++",
-    GDB="msp430-gdb",
-    OBJCOPY="msp430-objcopy",
-    RANLIB="msp430-ranlib",
-    SIZETOOL="msp430-size",
+    AR="msp430-elf-ar",
+    AS="msp430-elf-as",
+    CC="msp430-elf-gcc",
+    CXX="msp430-elf-g++",
+    GDB="msp430-elf-gdb",
+    OBJCOPY="msp430-elf-objcopy",
+    RANLIB="msp430-elf-ranlib",
+    SIZETOOL="msp430-elf-size",
     LINK="$CC",
 
     ARFLAGS=["rc"],

--- a/builder/main.py
+++ b/builder/main.py
@@ -64,6 +64,9 @@ env.Append(
         "-Os",
         "-ffunction-sections",  # place each function in its own section
         "-fdata-sections",
+        "-mlarge", # use large memory-model automatically.
+        "-mcode-region=either", # https://github.com/maxgerhardt/platform-timsp430
+        "-mdata-region=either"  # github user maxgerhardt added this fix
     ],
 
     CXXFLAGS=[
@@ -77,7 +80,10 @@ env.Append(
 
     LINKFLAGS=machine_flags + [
         "-Os",
-        "-Wl,-gc-sections,-u,main"
+        "-Wl,-gc-sections,-u,main",
+        "-mlarge", # use large memory-model also at the linker stage
+        "-mcode-region=either", # https://github.com/maxgerhardt/platform-timsp430
+        "-mdata-region=either"  # github user maxgerhardt added this fix
     ],
 
     LIBS=["m"],

--- a/platform.json
+++ b/platform.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/platformio/platform-timsp430.git"
+    "url": "https://github.com/thijses/platform-timsp430-newGCC.git"
   },
   "version": "2.4.0",
   "frameworks": {


### PR DESCRIPTION
a while back, a user by the name of @maxgerhardt made a fork for using a newer toolchain (provided by TI's website). 
https://github.com/maxgerhardt/pio-toolchaintimsp430-new
I know next-to-nothing about compilers, but it seems to make that toolchain work you only need to specify it in platformio.ini and fix 2 files in this repository. The official platformIO MSP430 toolchain uses GCC4.6.3, which means C++0x. I happen to strongly prefer C++11 (for the record, i did not know there were significant differences in C++ versions over recent years). Could someone please explain to me why TI's opensource (modern) toolchain is not used?
Sincerely,
Thijs